### PR TITLE
Add new accompanying `offset` utilities for offsetting safe values

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line unicorn/prefer-module
 const plugin = require('tailwindcss/plugin')
 
-const safeArea = plugin(({addUtilities}) => {
+const safeArea = plugin(({addUtilities,matchUtilities,theme}) => {
 	const utilities = {
 		'.m-safe': {
 			marginTop: 'env(safe-area-inset-top)',
@@ -68,8 +68,24 @@ const safeArea = plugin(({addUtilities}) => {
 			],
 		},
 	}
-
 	addUtilities(utilities)
+
+	const matchedUtilities = Object.entries(utilities).reduce((accu, [selector, propertyValue]) => {
+		const className = selector.slice(1);
+		accu[`${className}-offset`] = (x) => Object.entries(propertyValue).reduce((accu, [property, value]) => {
+			if (Array.isArray(value)) {
+				accu[property] = value.map((v, i) => i ? i : `calc(${v} + ${x})`)
+			} else {
+				accu[property] = `calc(${value} + ${x})`
+			}
+			return accu
+		}, {})
+		return accu
+	}, {})
+	matchUtilities(matchedUtilities, {
+		values: theme('spacing'),
+		supportsNegativeValues: true,
+	})
 })
 
 // eslint-disable-next-line unicorn/prefer-module

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 const plugin = require('tailwindcss/plugin')
 
 const safeArea = plugin(({addUtilities,matchUtilities,theme}) => {
-	const utilities = {
+	const baseUtilities = {
 		'.m-safe': {
 			marginTop: 'env(safe-area-inset-top)',
 			marginRight: 'env(safe-area-inset-right)',
@@ -68,9 +68,9 @@ const safeArea = plugin(({addUtilities,matchUtilities,theme}) => {
 			],
 		},
 	}
-	addUtilities(utilities)
+	addUtilities(baseUtilities)
 
-	const matchedUtilities = Object.entries(utilities).reduce((accu, [selector, propertyValue]) => {
+	const offsetUtilities = Object.entries(baseUtilities).reduce((accu, [selector, propertyValue]) => {
 		const className = selector.slice(1);
 		accu[`${className}-offset`] = (x) => Object.entries(propertyValue).reduce((accu, [property, value]) => {
 			if (Array.isArray(value)) {
@@ -82,7 +82,24 @@ const safeArea = plugin(({addUtilities,matchUtilities,theme}) => {
 		}, {})
 		return accu
 	}, {})
-	matchUtilities(matchedUtilities, {
+	matchUtilities(offsetUtilities, {
+		values: theme('spacing'),
+		supportsNegativeValues: true,
+	})
+
+	const orUtilities = Object.entries(baseUtilities).reduce((accu, [selector, propertyValue]) => {
+		const className = selector.slice(1);
+		accu[`${className}-or`] = (x) => Object.entries(propertyValue).reduce((accu, [property, value]) => {
+			if (Array.isArray(value)) {
+				accu[property] = value.map((v, i) => i ? i : `max(${v}, ${x})`)
+			} else {
+				accu[property] = `max(${value}, ${x})`
+			}
+			return accu
+		}, {})
+		return accu
+	}, {})
+	matchUtilities(orUtilities, {
 		values: theme('spacing'),
 		supportsNegativeValues: true,
 	})

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line unicorn/prefer-module
 const plugin = require('tailwindcss/plugin')
 
-const safeArea = plugin(({addUtilities,matchUtilities,theme}) => {
+const safeArea = plugin(({addUtilities, matchUtilities, theme}) => {
 	const baseUtilities = {
 		'.m-safe': {
 			marginTop: 'env(safe-area-inset-top)',
@@ -70,35 +70,43 @@ const safeArea = plugin(({addUtilities,matchUtilities,theme}) => {
 	}
 	addUtilities(baseUtilities)
 
-	const offsetUtilities = Object.entries(baseUtilities).reduce((accu, [selector, propertyValue]) => {
-		const className = selector.slice(1);
-		accu[`${className}-offset`] = (x) => Object.entries(propertyValue).reduce((accu, [property, value]) => {
-			if (Array.isArray(value)) {
-				accu[property] = value.map((v, i) => i ? i : `calc(${v} + ${x})`)
-			} else {
-				accu[property] = `calc(${value} + ${x})`
-			}
+	const offsetUtilities = Object.entries(baseUtilities).reduce(
+		(accu, [selector, propertyValue]) => {
+			const className = selector.slice(1)
+			accu[`${className}-offset`] = (x) =>
+				Object.entries(propertyValue).reduce((accu, [property, value]) => {
+					if (Array.isArray(value)) {
+						accu[property] = value.map((v, i) => (i ? i : `calc(${v} + ${x})`))
+					} else {
+						accu[property] = `calc(${value} + ${x})`
+					}
+					return accu
+				}, {})
 			return accu
-		}, {})
-		return accu
-	}, {})
+		},
+		{}
+	)
 	matchUtilities(offsetUtilities, {
 		values: theme('spacing'),
 		supportsNegativeValues: true,
 	})
 
-	const orUtilities = Object.entries(baseUtilities).reduce((accu, [selector, propertyValue]) => {
-		const className = selector.slice(1);
-		accu[`${className}-or`] = (x) => Object.entries(propertyValue).reduce((accu, [property, value]) => {
-			if (Array.isArray(value)) {
-				accu[property] = value.map((v, i) => i ? i : `max(${v}, ${x})`)
-			} else {
-				accu[property] = `max(${value}, ${x})`
-			}
+	const orUtilities = Object.entries(baseUtilities).reduce(
+		(accu, [selector, propertyValue]) => {
+			const className = selector.slice(1)
+			accu[`${className}-or`] = (x) =>
+				Object.entries(propertyValue).reduce((accu, [property, value]) => {
+					if (Array.isArray(value)) {
+						accu[property] = value.map((v, i) => (i ? i : `max(${v}, ${x})`))
+					} else {
+						accu[property] = `max(${value}, ${x})`
+					}
+					return accu
+				}, {})
 			return accu
-		}, {})
-		return accu
-	}, {})
+		},
+		{}
+	)
 	matchUtilities(orUtilities, {
 		values: theme('spacing'),
 		supportsNegativeValues: true,

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # tailwindcss-safe-area
 
-Safe area inset utilities extending margin, padding, and height
+Safe area inset utilities extending margin, padding, and height. The plugin provides base, offset, and or utilities for better adaptability across various scenarios.
 
 ## Getting started
 
@@ -20,9 +20,17 @@ module.exports = {
 
 ## Usage
 
-This plugin extends the padding and margin utilities.
+This plugin extends the padding and margin utilities with three types:
 
-Use the `*-safe` utilities:
+1. **Base Utilities**: The base safe area inset utilities. These include the initial padding and margin utilities with the safe area in consideration. They can be used where you want the element to respect the safe area insets.
+
+2. **Offset Utilities**: These utilities allow you to extend the base safe area inset by a given offset. This can be particularly useful when you want a bit more spacing than the safe area provides, for example in situations where you have a translucent UI over a background image or video and want to ensure important visual content isn't covered.
+
+3. **Or Utilities**: These utilities let you specify a minimum value to use if it's greater than the safe area inset. This can be used when you have certain layout elements that should respect the safe area but should never be smaller than a certain size.
+
+Here are some examples:
+
+### Base utilities
 
 ```html
 <header class="pt-safe">...</header>
@@ -32,6 +40,22 @@ Use the `*-safe` utilities:
 </main>
 
 <footer class="pb-safe">...</footer>
+```
+
+### Offset utilities
+
+The offset utilities can be used by appending `-offset-{value}` to the base utility. This applies an additional margin or padding equal to the specified value. For example, if you want to apply a right padding that is equal to the safe area inset plus 4 units of your spacing scale, you can use:
+
+```html
+<div class="pr-safe-offset-4">...</div>
+```
+
+### Or utilities
+
+The or utilities can be used by appending `-or-{value}` to the base utility. This applies a margin or padding that is the larger of the safe area inset and the specified value. For example, if you want to apply a bottom padding that is the larger of the safe area inset and 8 units of your spacing scale, you can use:
+
+```html
+<div class="pb-safe-or-8">...</div>
 ```
 
 ## Provided utilities
@@ -45,8 +69,9 @@ Use the `*-safe` utilities:
 | `mr-safe, pr-safe`                 | `env(safe-area-inset-right)`                                             |
 | `mb-safe, pb-safe`                 | `env(safe-area-inset-bottom)`                                            |
 | `ml-safe, pl-safe`                 | `env(safe-area-inset-left)`                                              |
-| `min-h-screen-safe, h-screen-safe` | `calc(100vh - (env(safe-area-inset-top) + env(safe-area-inset-bottom)))` |
-|                                    | `-webkit-fill-available`                                                 |
+| `min-h-screen-safe, h-screen-safe` | `calc(100vh - (env(safe-area-inset-top) + env(safe-area-inset-bottom)))`<br>`-webkit-fill-available`                                                 |
+| `*-safe-offset-{value}`            | `calc(env(safe-area-inset-*) + {value})`                                 |
+| `*-safe-or-{value}`                | `max(env(safe-area-inset-*), {value})`                                   |
 
 > Tip: To extend html content behind the safe area, set `viewport-fit=cover`
 
@@ -56,6 +81,52 @@ Use the `*-safe` utilities:
 	content="width=device-width, initial-scale=1.0, viewport-fit=cover"
 />
 ```
+
+<details><summary><h4> Examples with generated output</h4></summary>
+
+#### Base Utility Example
+
+```html
+<header class="pt-safe">...</header>
+```
+
+This applies a top padding to the header that is equal to the safe area inset at the top. The generated CSS would be:
+
+```css
+.pt-safe {
+  padding-top: env(safe-area-inset-top);
+}
+```
+
+#### Offset Utility Example
+
+```html
+<div class="pr-safe-offset-4">...</div>
+```
+
+This applies a right padding to the div that is equal to the safe area inset on the right plus 4 units of your spacing scale. Assuming your spacing scale unit is 8px (default in Tailwind CSS), the generated CSS would be:
+
+```css
+.pr-safe-offset-4 {
+  padding-right: calc(env(safe-area-inset-right) + 1rem);
+}
+```
+
+#### Or Utility Example
+
+```html
+<div class="pb-safe-or-8">...</div>
+```
+
+This applies a bottom padding to the div that is the larger of the safe area inset at the bottom and 8 units of your spacing scale. Assuming your spacing scale unit is 8px (default in Tailwind CSS), the generated CSS would be:
+
+```css
+.pb-safe-or-8 {
+  padding-bottom: max(env(safe-area-inset-bottom), 2rem);
+}
+```
+
+</details>
 
 ## Troubleshooting
 


### PR DESCRIPTION
### The problem

Using this for a short while now, I still encounter quite a few situations where I need to fall back to using an `env(safe-area-inset-…)` value explicitly to include some sort of offset like this utility example:

```html
<div class="pb-[calc(1rem+env(safe-area-inset-bottom))]"></div>
```

### Description of the changes

This PR adds support for new accompanying `offset` utilities which factor an offset into the safe values.

For example, this HTML:

```html
<div class="pb-safe-offset-4 pt-safe"></div>
```

would generate this CSS:

```css
.pt-safe {
  padding-top: env(safe-area-inset-top);
}

.pb-safe-offset-4 {
  padding-bottom: calc(env(safe-area-inset-bottom) + 1rem);
}
```


View this example on Tailwind Play here: https://play.tailwindcss.com/CcauDKvCCi

### Notes

In an effort to make this as easy to maintain as your existing utilities, I've built this addition as a `reduce` that wraps your existing utilities, so as you add/modify standard utilities, the same changes will apply to these matched counterparts automatically.

### Considerations

It may be possible to omit the word "offset" altogether to make this usage more concise like `pb-safe-4` but I found that a bit less clear than including "offset". In this case, I think the verboseness actually adds considerable value.