### PR TITLE
fix: unwanted `(min-)height: 1px`

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,7 +87,9 @@ const safeArea = plugin(({addUtilities, matchUtilities, theme}) => {
 			accu[`${className}-offset`] = (x) =>
 				Object.entries(propertyValue).reduce((accu, [property, value]) => {
 					if (Array.isArray(value)) {
-						accu[property] = value.map((v, i) => (i ? i : `calc(${v} + ${x})`))
+						accu[property] = value.map((v) =>
+							v === '-webkit-fill-available' ? v : `calc(${v} + ${x})`
+						)
 					} else {
 						accu[property] = `calc(${value} + ${x})`
 					}
@@ -108,7 +110,9 @@ const safeArea = plugin(({addUtilities, matchUtilities, theme}) => {
 			accu[`${className}-or`] = (x) =>
 				Object.entries(propertyValue).reduce((accu, [property, value]) => {
 					if (Array.isArray(value)) {
-						accu[property] = value.map((v, i) => (i ? i : `max(${v}, ${x})`))
+						accu[property] = value.map((v, i) =>
+							v === '-webkit-fill-available' ? v : `max(${v}, ${x})`
+						)
 					} else {
 						accu[property] = `max(${value}, ${x})`
 					}


### PR DESCRIPTION
Currently, `.min-h-screen-safe` and `.h-screen-safe` generates wrong CSS rules.

```diff
.min-h-screen-safe {
  min-height: calc(100vh - (env(safe-area-inset-top) + env(safe-area-inset-bottom)));
-  min-height: -webkit-fill-available; /* expected */
+  min-height: 1px; /* actual */
}
```

This PR fixes `offset` and `or` utilities generation processes to generate expected CSS rules.