### PR TITLE
fix: tailwindcss as devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,11 @@
 		"margin",
 		"padding"
 	],
+	"peerDependencies": {
+    "tailwindcss": "^2.0.0 || >=3.0.0"
+  },
 	"devDependencies": {
-		"prettier": "^2.5.1",
-		"tailwindcss": "^3.0.8"
+		"prettier": "^2.5.1"
 	},
 	"prettier": {
 		"bracketSpacing": false,


### PR DESCRIPTION
This line requires _tailwindcss_ to be installed as a dependency rather than a devDependency:
```
const plugin = require('tailwindcss/plugin')
```

Yarn check packages with their imports and corresponding package.json entrys. This PR will make
_tailwindcss-safe-area_ work again with Yarn projects.