### PR TITLE
fix: remove --dev from install command

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ Tailwind CSS utilities for safe areas.
 ## Getting started
 
 ```sh
-npm install --dev tailwindcss-safe-area
+npm install tailwindcss-safe-area
 ```
 
 Then add the plugin to your `tailwind.config.js` file:


### PR DESCRIPTION
TailwindCSS currently recommends installation as a standard dependency per [Next.js install guide](https://tailwindcss.com/docs/installation/framework-guides/nextjs). This commit updates the install command to match TailwindCSS for consistency.

If the current dependency type is retained, --save-dev or -D is recommended per [NPM
docs](https://docs.npmjs.com/specifying-dependencies-and-devdependencies-in-a-package-json-file#adding-dependencies-to-a-packagejson-file-from-the-command-line).