### PR TITLE
feat: add negative utilities

### DIFF
--- a/index.css
+++ b/index.css
@@ -5,31 +5,63 @@
 	margin-bottom: env(safe-area-inset-bottom);
 	margin-left: env(safe-area-inset-left);
 }
+@utility -m-safe {
+	margin-top: calc(env(safe-area-inset-top) * -1);
+	margin-right: calc(env(safe-area-inset-right) * -1);
+	margin-bottom: calc(env(safe-area-inset-bottom) * -1);
+	margin-left: calc(env(safe-area-inset-left) * -1);
+}
 @utility mx-safe {
 	margin-right: env(safe-area-inset-right);
 	margin-left: env(safe-area-inset-left);
+}
+@utility -mx-safe {
+	margin-right: calc(env(safe-area-inset-right) * -1);
+	margin-left: calc(env(safe-area-inset-left) * -1);
 }
 @utility my-safe {
 	margin-top: env(safe-area-inset-top);
 	margin-bottom: env(safe-area-inset-bottom);
 }
+@utility -my-safe {
+	margin-top: calc(env(safe-area-inset-top) * -1);
+	margin-bottom: calc(env(safe-area-inset-bottom) * -1);
+}
 @utility ms-safe {
 	margin-inline-start: env(safe-area-inset-left);
+}
+@utility -ms-safe {
+	margin-inline-start: calc(env(safe-area-inset-left) * -1);
 }
 @utility me-safe {
 	margin-inline-end: env(safe-area-inset-right);
 }
+@utility -me-safe {
+	margin-inline-end: calc(env(safe-area-inset-right) * -1);
+}
 @utility mt-safe {
 	margin-top: env(safe-area-inset-top);
+}
+@utility -mt-safe {
+	margin-top: calc(env(safe-area-inset-top) * -1);
 }
 @utility mr-safe {
 	margin-right: env(safe-area-inset-right);
 }
+@utility -mr-safe {
+	margin-right: calc(env(safe-area-inset-right) * -1);
+}
 @utility mb-safe {
 	margin-bottom: env(safe-area-inset-bottom);
 }
+@utility -mb-safe {
+	margin-bottom: calc(env(safe-area-inset-bottom) * -1);
+}
 @utility ml-safe {
 	margin-left: env(safe-area-inset-left);
+}
+@utility -ml-safe {
+	margin-left: calc(env(safe-area-inset-left) * -1);
 }
 
 /* Base padding utilities */
@@ -39,31 +71,63 @@
 	padding-bottom: env(safe-area-inset-bottom);
 	padding-left: env(safe-area-inset-left);
 }
+@utility -p-safe {
+	padding-top: calc(env(safe-area-inset-top) * -1);
+	padding-right: calc(env(safe-area-inset-right) * -1);
+	padding-bottom: calc(env(safe-area-inset-bottom) * -1);
+	padding-left: calc(env(safe-area-inset-left) * -1);
+}
 @utility px-safe {
 	padding-right: env(safe-area-inset-right);
 	padding-left: env(safe-area-inset-left);
+}
+@utility -px-safe {
+	padding-right: calc(env(safe-area-inset-right) * -1);
+	padding-left: calc(env(safe-area-inset-left) * -1);
 }
 @utility py-safe {
 	padding-top: env(safe-area-inset-top);
 	padding-bottom: env(safe-area-inset-bottom);
 }
+@utility -py-safe {
+	padding-top: calc(env(safe-area-inset-top) * -1);
+	padding-bottom: calc(env(safe-area-inset-bottom) * -1);
+}
 @utility ps-safe {
 	padding-inline-start: env(safe-area-inset-left);
+}
+@utility -ps-safe {
+	padding-inline-start: calc(env(safe-area-inset-left) * -1);
 }
 @utility pe-safe {
 	padding-inline-end: env(safe-area-inset-right);
 }
+@utility -pe-safe {
+	padding-inline-end: calc(env(safe-area-inset-right) * -1);
+}
 @utility pt-safe {
 	padding-top: env(safe-area-inset-top);
+}
+@utility -pt-safe {
+	padding-top: calc(env(safe-area-inset-top) * -1);
 }
 @utility pr-safe {
 	padding-right: env(safe-area-inset-right);
 }
+@utility -pr-safe {
+	padding-right: calc(env(safe-area-inset-right) * -1);
+}
 @utility pb-safe {
 	padding-bottom: env(safe-area-inset-bottom);
 }
+@utility -pb-safe {
+	padding-bottom: calc(env(safe-area-inset-bottom) * -1);
+}
 @utility pl-safe {
 	padding-left: env(safe-area-inset-left);
+}
+@utility -pl-safe {
+	padding-left: calc(env(safe-area-inset-left) * -1);
 }
 
 /* Scroll margin utilities */
@@ -73,31 +137,63 @@
 	scroll-margin-bottom: env(safe-area-inset-bottom);
 	scroll-margin-left: env(safe-area-inset-left);
 }
+@utility -scroll-m-safe {
+	scroll-margin-top: calc(env(safe-area-inset-top) * -1);
+	scroll-margin-right: calc(env(safe-area-inset-right) * -1);
+	scroll-margin-bottom: calc(env(safe-area-inset-bottom) * -1);
+	scroll-margin-left: calc(env(safe-area-inset-left) * -1);
+}
 @utility scroll-mx-safe {
 	scroll-margin-right: env(safe-area-inset-right);
 	scroll-margin-left: env(safe-area-inset-left);
+}
+@utility -scroll-mx-safe {
+	scroll-margin-right: calc(env(safe-area-inset-right) * -1);
+	scroll-margin-left: calc(env(safe-area-inset-left) * -1);
 }
 @utility scroll-my-safe {
 	scroll-margin-top: env(safe-area-inset-top);
 	scroll-margin-bottom: env(safe-area-inset-bottom);
 }
+@utility -scroll-my-safe {
+	scroll-margin-top: calc(env(safe-area-inset-top) * -1);
+	scroll-margin-bottom: calc(env(safe-area-inset-bottom) * -1);
+}
 @utility scroll-ms-safe {
 	scroll-margin-inline-start: env(safe-area-inset-left);
+}
+@utility -scroll-ms-safe {
+	scroll-margin-inline-start: calc(env(safe-area-inset-left) * -1);
 }
 @utility scroll-me-safe {
 	scroll-margin-inline-end: env(safe-area-inset-right);
 }
+@utility -scroll-me-safe {
+	scroll-margin-inline-end: calc(env(safe-area-inset-right) * -1);
+}
 @utility scroll-mt-safe {
 	scroll-margin-top: env(safe-area-inset-top);
+}
+@utility -scroll-mt-safe {
+	scroll-margin-top: calc(env(safe-area-inset-top) * -1);
 }
 @utility scroll-mr-safe {
 	scroll-margin-right: env(safe-area-inset-right);
 }
+@utility -scroll-mr-safe {
+	scroll-margin-right: calc(env(safe-area-inset-right) * -1);
+}
 @utility scroll-mb-safe {
 	scroll-margin-bottom: env(safe-area-inset-bottom);
 }
+@utility -scroll-mb-safe {
+	scroll-margin-bottom: calc(env(safe-area-inset-bottom) * -1);
+}
 @utility scroll-ml-safe {
 	scroll-margin-left: env(safe-area-inset-left);
+}
+@utility -scroll-ml-safe {
+	scroll-margin-left: calc(env(safe-area-inset-left) * -1);
 }
 
 /* Scroll padding utilities */
@@ -107,31 +203,63 @@
 	scroll-padding-bottom: env(safe-area-inset-bottom);
 	scroll-padding-left: env(safe-area-inset-left);
 }
+@utility -scroll-p-safe {
+	scroll-padding-top: calc(env(safe-area-inset-top) * -1);
+	scroll-padding-right: calc(env(safe-area-inset-right) * -1);
+	scroll-padding-bottom: calc(env(safe-area-inset-bottom) * -1);
+	scroll-padding-left: calc(env(safe-area-inset-left) * -1);
+}
 @utility scroll-px-safe {
 	scroll-padding-right: env(safe-area-inset-right);
 	scroll-padding-left: env(safe-area-inset-left);
+}
+@utility -scroll-px-safe {
+	scroll-padding-right: calc(env(safe-area-inset-right) * -1);
+	scroll-padding-left: calc(env(safe-area-inset-left) * -1);
 }
 @utility scroll-py-safe {
 	scroll-padding-top: env(safe-area-inset-top);
 	scroll-padding-bottom: env(safe-area-inset-bottom);
 }
+@utility -scroll-py-safe {
+	scroll-padding-top: calc(env(safe-area-inset-top) * -1);
+	scroll-padding-bottom: calc(env(safe-area-inset-bottom) * -1);
+}
 @utility scroll-ps-safe {
 	scroll-padding-inline-start: env(safe-area-inset-left);
+}
+@utility -scroll-ps-safe {
+	scroll-padding-inline-start: calc(env(safe-area-inset-left) * -1);
 }
 @utility scroll-pe-safe {
 	scroll-padding-inline-end: env(safe-area-inset-right);
 }
+@utility -scroll-pe-safe {
+	scroll-padding-inline-end: calc(env(safe-area-inset-right) * -1);
+}
 @utility scroll-pt-safe {
 	scroll-padding-top: env(safe-area-inset-top);
+}
+@utility -scroll-pt-safe {
+	scroll-padding-top: calc(env(safe-area-inset-top) * -1);
 }
 @utility scroll-pr-safe {
 	scroll-padding-right: env(safe-area-inset-right);
 }
+@utility -scroll-pr-safe {
+	scroll-padding-right: calc(env(safe-area-inset-right) * -1);
+}
 @utility scroll-pb-safe {
 	scroll-padding-bottom: env(safe-area-inset-bottom);
 }
+@utility -scroll-pb-safe {
+	scroll-padding-bottom: calc(env(safe-area-inset-bottom) * -1);
+}
 @utility scroll-pl-safe {
 	scroll-padding-left: env(safe-area-inset-left);
+}
+@utility -scroll-pl-safe {
+	scroll-padding-left: calc(env(safe-area-inset-left) * -1);
 }
 
 /* Inset utilities */
@@ -141,31 +269,63 @@
 	bottom: env(safe-area-inset-bottom);
 	left: env(safe-area-inset-left);
 }
+@utility -inset-safe {
+	top: calc(env(safe-area-inset-top) * -1);
+	right: calc(env(safe-area-inset-right) * -1);
+	bottom: calc(env(safe-area-inset-bottom) * -1);
+	left: calc(env(safe-area-inset-left) * -1);
+}
 @utility inset-x-safe {
 	right: env(safe-area-inset-right);
 	left: env(safe-area-inset-left);
+}
+@utility -inset-x-safe {
+	right: calc(env(safe-area-inset-right) * -1);
+	left: calc(env(safe-area-inset-left) * -1);
 }
 @utility inset-y-safe {
 	top: env(safe-area-inset-top);
 	bottom: env(safe-area-inset-bottom);
 }
+@utility -inset-y-safe {
+	top: calc(env(safe-area-inset-top) * -1);
+	bottom: calc(env(safe-area-inset-bottom) * -1);
+}
 @utility start-safe {
 	inset-inline-start: env(safe-area-inset-left);
+}
+@utility -start-safe {
+	inset-inline-start: calc(env(safe-area-inset-left) * -1);
 }
 @utility end-safe {
 	inset-inline-end: env(safe-area-inset-right);
 }
+@utility -end-safe {
+	inset-inline-end: calc(env(safe-area-inset-right) * -1);
+}
 @utility top-safe {
 	top: env(safe-area-inset-top);
+}
+@utility -top-safe {
+	top: calc(env(safe-area-inset-top) * -1);
 }
 @utility right-safe {
 	right: env(safe-area-inset-right);
 }
+@utility -right-safe {
+	right: calc(env(safe-area-inset-right) * -1);
+}
 @utility bottom-safe {
 	bottom: env(safe-area-inset-bottom);
 }
+@utility -bottom-safe {
+	bottom: calc(env(safe-area-inset-bottom) * -1);
+}
 @utility left-safe {
 	left: env(safe-area-inset-left);
+}
+@utility -left-safe {
+	left: calc(env(safe-area-inset-left) * -1);
 }
 
 /* Height utilities */
@@ -270,6 +430,20 @@
 		--value(integer, [integer]) + env(safe-area-inset-left)
 	);
 }
+@utility -m-safe-offset-* {
+	margin-top: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-top) * -1
+	);
+	margin-right: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-right) * -1
+	);
+	margin-bottom: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-bottom) * -1
+	);
+	margin-left: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-left) * -1
+	);
+}
 @utility mx-safe-offset-* {
 	margin-right: --spacing(
 		--value(integer, [integer]) + env(safe-area-inset-right)
@@ -278,10 +452,26 @@
 		--value(integer, [integer]) + env(safe-area-inset-left)
 	);
 }
+@utility -mx-safe-offset-* {
+	margin-right: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-right) * -1
+	);
+	margin-left: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-left) * -1
+	);
+}
 @utility my-safe-offset-* {
 	margin-top: --spacing(--value(integer, [integer]) + env(safe-area-inset-top));
 	margin-bottom: --spacing(
 		--value(integer, [integer]) + env(safe-area-inset-bottom)
+	);
+}
+@utility -my-safe-offset-* {
+	margin-top: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-top) * -1
+	);
+	margin-bottom: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-bottom) * -1
 	);
 }
 @utility ms-safe-offset-* {
@@ -289,17 +479,37 @@
 		--value(integer, [integer]) + env(safe-area-inset-left)
 	);
 }
+@utility -ms-safe-offset-* {
+	margin-inline-start: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-left) * -1
+	);
+}
 @utility me-safe-offset-* {
 	margin-inline-end: --spacing(
 		--value(integer, [integer]) + env(safe-area-inset-right)
 	);
 }
+@utility -me-safe-offset-* {
+	margin-inline-end: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-right) * -1
+	);
+}
 @utility mt-safe-offset-* {
 	margin-top: --spacing(--value(integer, [integer]) + env(safe-area-inset-top));
+}
+@utility -mt-safe-offset-* {
+	margin-top: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-top) * -1
+	);
 }
 @utility mr-safe-offset-* {
 	margin-right: --spacing(
 		--value(integer, [integer]) + env(safe-area-inset-right)
+	);
+}
+@utility -mr-safe-offset-* {
+	margin-right: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-right) * -1
 	);
 }
 @utility mb-safe-offset-* {
@@ -307,9 +517,19 @@
 		--value(integer, [integer]) + env(safe-area-inset-bottom)
 	);
 }
+@utility -mb-safe-offset-* {
+	margin-bottom: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-bottom) * -1
+	);
+}
 @utility ml-safe-offset-* {
 	margin-left: --spacing(
 		--value(integer, [integer]) + env(safe-area-inset-left)
+	);
+}
+@utility -ml-safe-offset-* {
+	margin-left: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-left) * -1
 	);
 }
 
@@ -332,6 +552,24 @@
 		--spacing(--value(integer, [integer]))
 	);
 }
+@utility -m-safe-or-* {
+	margin-top: min(
+		calc(env(safe-area-inset-top) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
+	);
+	margin-right: min(
+		calc(env(safe-area-inset-right) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
+	);
+	margin-bottom: min(
+		calc(env(safe-area-inset-bottom) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
+	);
+	margin-left: min(
+		calc(env(safe-area-inset-left) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
+	);
+}
 @utility mx-safe-or-* {
 	margin-right: max(
 		env(safe-area-inset-right),
@@ -340,6 +578,16 @@
 	margin-left: max(
 		env(safe-area-inset-left),
 		--spacing(--value(integer, [integer]))
+	);
+}
+@utility -mx-safe-or-* {
+	margin-right: min(
+		calc(env(safe-area-inset-right) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
+	);
+	margin-left: min(
+		calc(env(safe-area-inset-left) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
 	);
 }
 @utility my-safe-or-* {
@@ -352,10 +600,26 @@
 		--spacing(--value(integer, [integer]))
 	);
 }
+@utility -my-safe-or-* {
+	margin-top: min(
+		calc(env(safe-area-inset-top) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
+	);
+	margin-bottom: min(
+		calc(env(safe-area-inset-bottom) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
+	);
+}
 @utility ms-safe-or-* {
 	margin-inline-start: max(
 		env(safe-area-inset-left),
 		--spacing(--value(integer, [integer]))
+	);
+}
+@utility -ms-safe-or-* {
+	margin-inline-start: min(
+		calc(env(safe-area-inset-left) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
 	);
 }
 @utility me-safe-or-* {
@@ -364,10 +628,22 @@
 		--spacing(--value(integer, [integer]))
 	);
 }
+@utility -me-safe-or-* {
+	margin-inline-end: min(
+		calc(env(safe-area-inset-right) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
+	);
+}
 @utility mt-safe-or-* {
 	margin-top: max(
 		env(safe-area-inset-top),
 		--spacing(--value(integer, [integer]))
+	);
+}
+@utility -mt-safe-or-* {
+	margin-top: min(
+		calc(env(safe-area-inset-top) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
 	);
 }
 @utility mr-safe-or-* {
@@ -376,16 +652,34 @@
 		--spacing(--value(integer, [integer]))
 	);
 }
+@utility -mr-safe-or-* {
+	margin-right: min(
+		calc(env(safe-area-inset-right) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
+	);
+}
 @utility mb-safe-or-* {
 	margin-bottom: max(
 		env(safe-area-inset-bottom),
 		--spacing(--value(integer, [integer]))
 	);
 }
+@utility -mb-safe-or-* {
+	margin-bottom: min(
+		calc(env(safe-area-inset-bottom) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
+	);
+}
 @utility ml-safe-or-* {
 	margin-left: max(
 		env(safe-area-inset-left),
 		--spacing(--value(integer, [integer]))
+	);
+}
+@utility -ml-safe-or-* {
+	margin-left: min(
+		calc(env(safe-area-inset-left) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
 	);
 }
 
@@ -404,12 +698,34 @@
 		--value(integer, [integer]) + env(safe-area-inset-left)
 	);
 }
+@utility -p-safe-offset-* {
+	padding-top: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-top) * -1
+	);
+	padding-right: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-right) * -1
+	);
+	padding-bottom: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-bottom) * -1
+	);
+	padding-left: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-left) * -1
+	);
+}
 @utility px-safe-offset-* {
 	padding-right: --spacing(
 		--value(integer, [integer]) + env(safe-area-inset-right)
 	);
 	padding-left: --spacing(
 		--value(integer, [integer]) + env(safe-area-inset-left)
+	);
+}
+@utility -px-safe-offset-* {
+	padding-right: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-right) * -1
+	);
+	padding-left: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-left) * -1
 	);
 }
 @utility py-safe-offset-* {
@@ -420,9 +736,22 @@
 		--value(integer, [integer]) + env(safe-area-inset-bottom)
 	);
 }
+@utility -py-safe-offset-* {
+	padding-top: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-top) * -1
+	);
+	padding-bottom: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-bottom) * -1
+	);
+}
 @utility ps-safe-offset-* {
 	padding-inline-start: --spacing(
 		--value(integer, [integer]) + env(safe-area-inset-left)
+	);
+}
+@utility -ps-safe-offset-* {
+	padding-inline-start: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-left) * -1
 	);
 }
 @utility pe-safe-offset-* {
@@ -430,9 +759,19 @@
 		--value(integer, [integer]) + env(safe-area-inset-right)
 	);
 }
+@utility -pe-safe-offset-* {
+	padding-inline-end: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-right) * -1
+	);
+}
 @utility pt-safe-offset-* {
 	padding-top: --spacing(
 		--value(integer, [integer]) + env(safe-area-inset-top)
+	);
+}
+@utility -pt-safe-offset-* {
+	padding-top: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-top) * -1
 	);
 }
 @utility pr-safe-offset-* {
@@ -440,14 +779,29 @@
 		--value(integer, [integer]) + env(safe-area-inset-right)
 	);
 }
+@utility -pr-safe-offset-* {
+	padding-right: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-right) * -1
+	);
+}
 @utility pb-safe-offset-* {
 	padding-bottom: --spacing(
 		--value(integer, [integer]) + env(safe-area-inset-bottom)
 	);
 }
+@utility -pb-safe-offset-* {
+	padding-bottom: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-bottom) * -1
+	);
+}
 @utility pl-safe-offset-* {
 	padding-left: --spacing(
 		--value(integer, [integer]) + env(safe-area-inset-left)
+	);
+}
+@utility -pl-safe-offset-* {
+	padding-left: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-left) * -1
 	);
 }
 
@@ -470,6 +824,24 @@
 		--spacing(--value(integer, [integer]))
 	);
 }
+@utility -p-safe-or-* {
+	padding-top: min(
+		calc(env(safe-area-inset-top) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
+	);
+	padding-right: min(
+		calc(env(safe-area-inset-right) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
+	);
+	padding-bottom: min(
+		calc(env(safe-area-inset-bottom) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
+	);
+	padding-left: min(
+		calc(env(safe-area-inset-left) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
+	);
+}
 @utility px-safe-or-* {
 	padding-right: max(
 		env(safe-area-inset-right),
@@ -478,6 +850,16 @@
 	padding-left: max(
 		env(safe-area-inset-left),
 		--spacing(--value(integer, [integer]))
+	);
+}
+@utility -px-safe-or-* {
+	padding-right: min(
+		calc(env(safe-area-inset-right) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
+	);
+	padding-left: min(
+		calc(env(safe-area-inset-left) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
 	);
 }
 @utility py-safe-or-* {
@@ -490,10 +872,26 @@
 		--spacing(--value(integer, [integer]))
 	);
 }
+@utility -py-safe-or-* {
+	padding-top: min(
+		calc(env(safe-area-inset-top) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
+	);
+	padding-bottom: min(
+		calc(env(safe-area-inset-bottom) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
+	);
+}
 @utility ps-safe-or-* {
 	padding-inline-start: max(
 		env(safe-area-inset-left),
 		--spacing(--value(integer, [integer]))
+	);
+}
+@utility -ps-safe-or-* {
+	padding-inline-start: min(
+		calc(env(safe-area-inset-left) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
 	);
 }
 @utility pe-safe-or-* {
@@ -502,10 +900,22 @@
 		--spacing(--value(integer, [integer]))
 	);
 }
+@utility -pe-safe-or-* {
+	padding-inline-end: min(
+		calc(env(safe-area-inset-right) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
+	);
+}
 @utility pt-safe-or-* {
 	padding-top: max(
 		env(safe-area-inset-top),
 		--spacing(--value(integer, [integer]))
+	);
+}
+@utility -pt-safe-or-* {
+	padding-top: min(
+		calc(env(safe-area-inset-top) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
 	);
 }
 @utility pr-safe-or-* {
@@ -514,16 +924,34 @@
 		--spacing(--value(integer, [integer]))
 	);
 }
+@utility -pr-safe-or-* {
+	padding-right: min(
+		calc(env(safe-area-inset-right) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
+	);
+}
 @utility pb-safe-or-* {
 	padding-bottom: max(
 		env(safe-area-inset-bottom),
 		--spacing(--value(integer, [integer]))
 	);
 }
+@utility -pb-safe-or-* {
+	padding-bottom: min(
+		calc(env(safe-area-inset-bottom) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
+	);
+}
 @utility pl-safe-or-* {
 	padding-left: max(
 		env(safe-area-inset-left),
 		--spacing(--value(integer, [integer]))
+	);
+}
+@utility -pl-safe-or-* {
+	padding-left: min(
+		calc(env(safe-area-inset-left) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
 	);
 }
 
@@ -542,12 +970,34 @@
 		--value(integer, [integer]) + env(safe-area-inset-left)
 	);
 }
+@utility -scroll-m-safe-offset-* {
+	scroll-margin-top: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-top) * -1
+	);
+	scroll-margin-right: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-right) * -1
+	);
+	scroll-margin-bottom: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-bottom) * -1
+	);
+	scroll-margin-left: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-left) * -1
+	);
+}
 @utility scroll-mx-safe-offset-* {
 	scroll-margin-right: --spacing(
 		--value(integer, [integer]) + env(safe-area-inset-right)
 	);
 	scroll-margin-left: --spacing(
 		--value(integer, [integer]) + env(safe-area-inset-left)
+	);
+}
+@utility -scroll-mx-safe-offset-* {
+	scroll-margin-right: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-right) * -1
+	);
+	scroll-margin-left: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-left) * -1
 	);
 }
 @utility scroll-my-safe-offset-* {
@@ -558,9 +1008,22 @@
 		--value(integer, [integer]) + env(safe-area-inset-bottom)
 	);
 }
+@utility -scroll-my-safe-offset-* {
+	scroll-margin-top: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-top) * -1
+	);
+	scroll-margin-bottom: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-bottom) * -1
+	);
+}
 @utility scroll-ms-safe-offset-* {
 	scroll-margin-inline-start: --spacing(
 		--value(integer, [integer]) + env(safe-area-inset-left)
+	);
+}
+@utility -scroll-ms-safe-offset-* {
+	scroll-margin-inline-start: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-left) * -1
 	);
 }
 @utility scroll-me-safe-offset-* {
@@ -568,9 +1031,19 @@
 		--value(integer, [integer]) + env(safe-area-inset-right)
 	);
 }
+@utility -scroll-me-safe-offset-* {
+	scroll-margin-inline-end: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-right) * -1
+	);
+}
 @utility scroll-mt-safe-offset-* {
 	scroll-margin-top: --spacing(
 		--value(integer, [integer]) + env(safe-area-inset-top)
+	);
+}
+@utility -scroll-mt-safe-offset-* {
+	scroll-margin-top: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-top) * -1
 	);
 }
 @utility scroll-mr-safe-offset-* {
@@ -578,14 +1051,29 @@
 		--value(integer, [integer]) + env(safe-area-inset-right)
 	);
 }
+@utility -scroll-mr-safe-offset-* {
+	scroll-margin-right: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-right) * -1
+	);
+}
 @utility scroll-mb-safe-offset-* {
 	scroll-margin-bottom: --spacing(
 		--value(integer, [integer]) + env(safe-area-inset-bottom)
 	);
 }
+@utility -scroll-mb-safe-offset-* {
+	scroll-margin-bottom: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-bottom) * -1
+	);
+}
 @utility scroll-ml-safe-offset-* {
 	scroll-margin-left: --spacing(
 		--value(integer, [integer]) + env(safe-area-inset-left)
+	);
+}
+@utility -scroll-ml-safe-offset-* {
+	scroll-margin-left: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-left) * -1
 	);
 }
 
@@ -608,6 +1096,24 @@
 		--spacing(--value(integer, [integer]))
 	);
 }
+@utility -scroll-m-safe-or-* {
+	scroll-margin-top: min(
+		calc(env(safe-area-inset-top) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
+	);
+	scroll-margin-right: min(
+		calc(env(safe-area-inset-right) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
+	);
+	scroll-margin-bottom: min(
+		calc(env(safe-area-inset-bottom) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
+	);
+	scroll-margin-left: min(
+		calc(env(safe-area-inset-left) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
+	);
+}
 @utility scroll-mx-safe-or-* {
 	scroll-margin-right: max(
 		env(safe-area-inset-right),
@@ -616,6 +1122,16 @@
 	scroll-margin-left: max(
 		env(safe-area-inset-left),
 		--spacing(--value(integer, [integer]))
+	);
+}
+@utility -scroll-mx-safe-or-* {
+	scroll-margin-right: min(
+		calc(env(safe-area-inset-right) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
+	);
+	scroll-margin-left: min(
+		calc(env(safe-area-inset-left) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
 	);
 }
 @utility scroll-my-safe-or-* {
@@ -628,10 +1144,26 @@
 		--spacing(--value(integer, [integer]))
 	);
 }
+@utility -scroll-my-safe-or-* {
+	scroll-margin-top: min(
+		calc(env(safe-area-inset-top) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
+	);
+	scroll-margin-bottom: min(
+		calc(env(safe-area-inset-bottom) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
+	);
+}
 @utility scroll-ms-safe-or-* {
 	scroll-margin-inline-start: max(
 		env(safe-area-inset-left),
 		--spacing(--value(integer, [integer]))
+	);
+}
+@utility -scroll-ms-safe-or-* {
+	scroll-margin-inline-start: min(
+		calc(env(safe-area-inset-left) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
 	);
 }
 @utility scroll-me-safe-or-* {
@@ -640,10 +1172,22 @@
 		--spacing(--value(integer, [integer]))
 	);
 }
+@utility -scroll-me-safe-or-* {
+	scroll-margin-inline-end: min(
+		calc(env(safe-area-inset-right) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
+	);
+}
 @utility scroll-mt-safe-or-* {
 	scroll-margin-top: max(
 		env(safe-area-inset-top),
 		--spacing(--value(integer, [integer]))
+	);
+}
+@utility -scroll-mt-safe-or-* {
+	scroll-margin-top: min(
+		calc(env(safe-area-inset-top) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
 	);
 }
 @utility scroll-mr-safe-or-* {
@@ -652,16 +1196,34 @@
 		--spacing(--value(integer, [integer]))
 	);
 }
+@utility -scroll-mr-safe-or-* {
+	scroll-margin-right: min(
+		calc(env(safe-area-inset-right) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
+	);
+}
 @utility scroll-mb-safe-or-* {
 	scroll-margin-bottom: max(
 		env(safe-area-inset-bottom),
 		--spacing(--value(integer, [integer]))
 	);
 }
+@utility -scroll-mb-safe-or-* {
+	scroll-margin-bottom: min(
+		calc(env(safe-area-inset-bottom) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
+	);
+}
 @utility scroll-ml-safe-or-* {
 	scroll-margin-left: max(
 		env(safe-area-inset-left),
 		--spacing(--value(integer, [integer]))
+	);
+}
+@utility -scroll-ml-safe-or-* {
+	scroll-margin-left: min(
+		calc(env(safe-area-inset-left) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
 	);
 }
 
@@ -680,12 +1242,34 @@
 		--value(integer, [integer]) + env(safe-area-inset-left)
 	);
 }
+@utility -scroll-p-safe-offset-* {
+	scroll-padding-top: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-top) * -1
+	);
+	scroll-padding-right: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-right) * -1
+	);
+	scroll-padding-bottom: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-bottom) * -1
+	);
+	scroll-padding-left: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-left) * -1
+	);
+}
 @utility scroll-px-safe-offset-* {
 	scroll-padding-right: --spacing(
 		--value(integer, [integer]) + env(safe-area-inset-right)
 	);
 	scroll-padding-left: --spacing(
 		--value(integer, [integer]) + env(safe-area-inset-left)
+	);
+}
+@utility -scroll-px-safe-offset-* {
+	scroll-padding-right: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-right) * -1
+	);
+	scroll-padding-left: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-left) * -1
 	);
 }
 @utility scroll-py-safe-offset-* {
@@ -696,9 +1280,22 @@
 		--value(integer, [integer]) + env(safe-area-inset-bottom)
 	);
 }
+@utility -scroll-py-safe-offset-* {
+	scroll-padding-top: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-top) * -1
+	);
+	scroll-padding-bottom: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-bottom) * -1
+	);
+}
 @utility scroll-ps-safe-offset-* {
 	scroll-padding-inline-start: --spacing(
 		--value(integer, [integer]) + env(safe-area-inset-left)
+	);
+}
+@utility -scroll-ps-safe-offset-* {
+	scroll-padding-inline-start: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-left) * -1
 	);
 }
 @utility scroll-pe-safe-offset-* {
@@ -706,9 +1303,19 @@
 		--value(integer, [integer]) + env(safe-area-inset-right)
 	);
 }
+@utility -scroll-pe-safe-offset-* {
+	scroll-padding-inline-end: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-right) * -1
+	);
+}
 @utility scroll-pt-safe-offset-* {
 	scroll-padding-top: --spacing(
 		--value(integer, [integer]) + env(safe-area-inset-top)
+	);
+}
+@utility -scroll-pt-safe-offset-* {
+	scroll-padding-top: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-top) * -1
 	);
 }
 @utility scroll-pr-safe-offset-* {
@@ -716,14 +1323,29 @@
 		--value(integer, [integer]) + env(safe-area-inset-right)
 	);
 }
+@utility -scroll-pr-safe-offset-* {
+	scroll-padding-right: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-right) * -1
+	);
+}
 @utility scroll-pb-safe-offset-* {
 	scroll-padding-bottom: --spacing(
 		--value(integer, [integer]) + env(safe-area-inset-bottom)
 	);
 }
+@utility -scroll-pb-safe-offset-* {
+	scroll-padding-bottom: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-bottom) * -1
+	);
+}
 @utility scroll-pl-safe-offset-* {
 	scroll-padding-left: --spacing(
 		--value(integer, [integer]) + env(safe-area-inset-left)
+	);
+}
+@utility -scroll-pl-safe-offset-* {
+	scroll-padding-left: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-left) * -1
 	);
 }
 
@@ -746,6 +1368,24 @@
 		--spacing(--value(integer, [integer]))
 	);
 }
+@utility -scroll-p-safe-or-* {
+	scroll-padding-top: min(
+		calc(env(safe-area-inset-top) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
+	);
+	scroll-padding-right: min(
+		calc(env(safe-area-inset-right) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
+	);
+	scroll-padding-bottom: min(
+		calc(env(safe-area-inset-bottom) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
+	);
+	scroll-padding-left: min(
+		calc(env(safe-area-inset-left) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
+	);
+}
 @utility scroll-px-safe-or-* {
 	scroll-padding-right: max(
 		env(safe-area-inset-right),
@@ -754,6 +1394,16 @@
 	scroll-padding-left: max(
 		env(safe-area-inset-left),
 		--spacing(--value(integer, [integer]))
+	);
+}
+@utility -scroll-px-safe-or-* {
+	scroll-padding-right: min(
+		calc(env(safe-area-inset-right) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
+	);
+	scroll-padding-left: min(
+		calc(env(safe-area-inset-left) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
 	);
 }
 @utility scroll-py-safe-or-* {
@@ -766,10 +1416,26 @@
 		--spacing(--value(integer, [integer]))
 	);
 }
+@utility -scroll-py-safe-or-* {
+	scroll-padding-top: min(
+		calc(env(safe-area-inset-top) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
+	);
+	scroll-padding-bottom: min(
+		calc(env(safe-area-inset-bottom) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
+	);
+}
 @utility scroll-ps-safe-or-* {
 	scroll-padding-inline-start: max(
 		env(safe-area-inset-left),
 		--spacing(--value(integer, [integer]))
+	);
+}
+@utility -scroll-ps-safe-or-* {
+	scroll-padding-inline-start: min(
+		calc(env(safe-area-inset-left) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
 	);
 }
 @utility scroll-pe-safe-or-* {
@@ -778,10 +1444,22 @@
 		--spacing(--value(integer, [integer]))
 	);
 }
+@utility -scroll-pe-safe-or-* {
+	scroll-padding-inline-end: min(
+		calc(env(safe-area-inset-right) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
+	);
+}
 @utility scroll-pt-safe-or-* {
 	scroll-padding-top: max(
 		env(safe-area-inset-top),
 		--spacing(--value(integer, [integer]))
+	);
+}
+@utility -scroll-pt-safe-or-* {
+	scroll-padding-top: min(
+		calc(env(safe-area-inset-top) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
 	);
 }
 @utility scroll-pr-safe-or-* {
@@ -790,16 +1468,34 @@
 		--spacing(--value(integer, [integer]))
 	);
 }
+@utility -scroll-pr-safe-or-* {
+	scroll-padding-right: min(
+		calc(env(safe-area-inset-right) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
+	);
+}
 @utility scroll-pb-safe-or-* {
 	scroll-padding-bottom: max(
 		env(safe-area-inset-bottom),
 		--spacing(--value(integer, [integer]))
 	);
 }
+@utility -scroll-pb-safe-or-* {
+	scroll-padding-bottom: min(
+		calc(env(safe-area-inset-bottom) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
+	);
+}
 @utility scroll-pl-safe-or-* {
 	scroll-padding-left: max(
 		env(safe-area-inset-left),
 		--spacing(--value(integer, [integer]))
+	);
+}
+@utility -scroll-pl-safe-or-* {
+	scroll-padding-left: min(
+		calc(env(safe-area-inset-left) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
 	);
 }
 
@@ -810,17 +1506,52 @@
 	bottom: --spacing(--value(integer, [integer]) + env(safe-area-inset-bottom));
 	left: --spacing(--value(integer, [integer]) + env(safe-area-inset-left));
 }
+@utility -inset-safe-offset-* {
+	top: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-top) * -1
+	);
+	right: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-right) * -1
+	);
+	bottom: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-bottom) * -1
+	);
+	left: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-left) * -1
+	);
+}
 @utility inset-x-safe-offset-* {
 	right: --spacing(--value(integer, [integer]) + env(safe-area-inset-right));
 	left: --spacing(--value(integer, [integer]) + env(safe-area-inset-left));
+}
+@utility -inset-x-safe-offset-* {
+	right: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-right) * -1
+	);
+	left: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-left) * -1
+	);
 }
 @utility inset-y-safe-offset-* {
 	top: --spacing(--value(integer, [integer]) + env(safe-area-inset-top));
 	bottom: --spacing(--value(integer, [integer]) + env(safe-area-inset-bottom));
 }
+@utility -inset-y-safe-offset-* {
+	top: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-top) * -1
+	);
+	bottom: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-bottom) * -1
+	);
+}
 @utility start-safe-offset-* {
 	inset-inline-start: --spacing(
 		--value(integer, [integer]) + env(safe-area-inset-left)
+	);
+}
+@utility -start-safe-offset-* {
+	inset-inline-start: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-left) * -1
 	);
 }
 @utility end-safe-offset-* {
@@ -828,17 +1559,42 @@
 		--value(integer, [integer]) + env(safe-area-inset-right)
 	);
 }
+@utility -end-safe-offset-* {
+	inset-inline-end: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-right) * -1
+	);
+}
 @utility top-safe-offset-* {
 	top: --spacing(--value(integer, [integer]) + env(safe-area-inset-top));
+}
+@utility -top-safe-offset-* {
+	top: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-top) * -1
+	);
 }
 @utility right-safe-offset-* {
 	right: --spacing(--value(integer, [integer]) + env(safe-area-inset-right));
 }
+@utility -right-safe-offset-* {
+	right: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-right) * -1
+	);
+}
 @utility bottom-safe-offset-* {
 	bottom: --spacing(--value(integer, [integer]) + env(safe-area-inset-bottom));
 }
+@utility -bottom-safe-offset-* {
+	bottom: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-bottom) * -1
+	);
+}
 @utility left-safe-offset-* {
 	left: --spacing(--value(integer, [integer]) + env(safe-area-inset-left));
+}
+@utility -left-safe-offset-* {
+	left: --spacing(
+		--value(integer, [integer]) * -1 + env(safe-area-inset-left) * -1
+	);
 }
 
 /* Inset utilities with or variant */
@@ -854,12 +1610,40 @@
 	);
 	left: max(env(safe-area-inset-left), --spacing(--value(integer, [integer])));
 }
+@utility -inset-safe-or-* {
+	top: min(
+		calc(env(safe-area-inset-top) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
+	);
+	right: min(
+		calc(env(safe-area-inset-right) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
+	);
+	bottom: min(
+		calc(env(safe-area-inset-bottom) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
+	);
+	left: min(
+		calc(env(safe-area-inset-left) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
+	);
+}
 @utility inset-x-safe-or-* {
 	right: max(
 		env(safe-area-inset-right),
 		--spacing(--value(integer, [integer]))
 	);
 	left: max(env(safe-area-inset-left), --spacing(--value(integer, [integer])));
+}
+@utility -inset-x-safe-or-* {
+	right: min(
+		calc(env(safe-area-inset-right) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
+	);
+	left: min(
+		calc(env(safe-area-inset-left) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
+	);
 }
 @utility inset-y-safe-or-* {
 	top: max(env(safe-area-inset-top), --spacing(--value(integer, [integer])));
@@ -868,10 +1652,26 @@
 		--spacing(--value(integer, [integer]))
 	);
 }
+@utility -inset-y-safe-or-* {
+	top: min(
+		calc(env(safe-area-inset-top) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
+	);
+	bottom: min(
+		calc(env(safe-area-inset-bottom) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
+	);
+}
 @utility start-safe-or-* {
 	inset-inline-start: max(
 		env(safe-area-inset-left),
 		--spacing(--value(integer, [integer]))
+	);
+}
+@utility -start-safe-or-* {
+	inset-inline-start: min(
+		calc(env(safe-area-inset-left) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
 	);
 }
 @utility end-safe-or-* {
@@ -880,13 +1680,31 @@
 		--spacing(--value(integer, [integer]))
 	);
 }
+@utility -end-safe-or-* {
+	inset-inline-end: min(
+		calc(env(safe-area-inset-right) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
+	);
+}
 @utility top-safe-or-* {
 	top: max(env(safe-area-inset-top), --spacing(--value(integer, [integer])));
+}
+@utility -top-safe-or-* {
+	top: min(
+		calc(env(safe-area-inset-top) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
+	);
 }
 @utility right-safe-or-* {
 	right: max(
 		env(safe-area-inset-right),
 		--spacing(--value(integer, [integer]))
+	);
+}
+@utility -right-safe-or-* {
+	right: min(
+		calc(env(safe-area-inset-right) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
 	);
 }
 @utility bottom-safe-or-* {
@@ -895,6 +1713,18 @@
 		--spacing(--value(integer, [integer]))
 	);
 }
+@utility -bottom-safe-or-* {
+	bottom: min(
+		calc(env(safe-area-inset-bottom) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
+	);
+}
 @utility left-safe-or-* {
 	left: max(env(safe-area-inset-left), --spacing(--value(integer, [integer])));
+}
+@utility -left-safe-or-* {
+	left: min(
+		calc(env(safe-area-inset-left) * -1),
+		calc(--spacing(--value(integer, [integer])) * -1)
+	);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "tailwindcss-safe-area",
-	"version": "1.0.0",
+	"version": "1.1.0-0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "tailwindcss-safe-area",
-			"version": "1.0.0",
+			"version": "1.1.0-0",
 			"license": "MIT",
 			"devDependencies": {
 				"@tailwindcss/cli": "^4.1.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "tailwindcss-safe-area",
-	"version": "1.0.0",
+	"version": "1.1.0-0",
 	"description": "Tailwind CSS safe area helpers",
 	"license": "MIT",
 	"repository": {

--- a/test/main.js
+++ b/test/main.js
@@ -45,227 +45,287 @@ before(async () => {
 	}
 });
 
-describe("Tailwind CSS Safe Area Plugin", () => {
+describe("Safe Area Utilities", () => {
 	const directions = ["top", "right", "bottom", "left"];
 
-	describe("Margin Utilities", () => {
-		test("basic margin utilities", () => {
-			expectSelectors([
-				".m-safe",
-				".mx-safe",
-				".my-safe",
-				".mt-safe",
-				".mr-safe",
-				".mb-safe",
-				".ml-safe",
-				".ms-safe",
-				".me-safe",
-			]);
+	test("margin", () => {
+		expectSelectors([
+			".m-safe",
+			".mx-safe",
+			".my-safe",
+			".mt-safe",
+			".mr-safe",
+			".mb-safe",
+			".ml-safe",
+			".ms-safe",
+			".me-safe",
+		]);
 
-			expectCSSProperties(
-				Object.fromEntries(
-					directions.map((d) => [`margin-${d}`, `env(safe-area-inset-${d})`]),
-				),
-			);
-		});
+		expectCSSProperties(
+			Object.fromEntries(
+				directions.map((d) => [`margin-${d}`, `env(safe-area-inset-${d})`]),
+			),
+		);
+	});
 
-		test("logical margin properties", () => {
-			expectCSSProperties({
-				"margin-inline-start": "env(safe-area-inset-left)",
-				"margin-inline-end": "env(safe-area-inset-right)",
-			});
+	test("negative margin", () => {
+		expectSelectors([
+			".-m-safe",
+			".-mx-safe",
+			".-my-safe",
+			".-mt-safe",
+			".-mr-safe",
+			".-mb-safe",
+			".-ml-safe",
+			".-ms-safe",
+			".-me-safe",
+		]);
+
+		expectCSSProperties(
+			Object.fromEntries(
+				directions.map((d) => [
+					`margin-${d}`,
+					`calc(env(safe-area-inset-${d}) * -1)`,
+				]),
+			),
+		);
+	});
+
+	test("logical margin", () => {
+		expectCSSProperties({
+			"margin-inline-start": "env(safe-area-inset-left)",
+			"margin-inline-end": "env(safe-area-inset-right)",
 		});
 	});
 
-	describe("Padding Utilities", () => {
-		test("basic padding utilities", () => {
-			expectSelectors([
-				".p-safe",
-				".px-safe",
-				".py-safe",
-				".pt-safe",
-				".pr-safe",
-				".pb-safe",
-				".pl-safe",
-				".ps-safe",
-				".pe-safe",
-			]);
-
-			expectCSSProperties(
-				Object.fromEntries(
-					directions.map((d) => [`padding-${d}`, `env(safe-area-inset-${d})`]),
-				),
-			);
-		});
-
-		test("logical padding properties", () => {
-			expectCSSProperties({
-				"padding-inline-start": "env(safe-area-inset-left)",
-				"padding-inline-end": "env(safe-area-inset-right)",
-			});
+	test("negative logical margin", () => {
+		expectCSSProperties({
+			"margin-inline-start": "calc(env(safe-area-inset-left) * -1)",
+			"margin-inline-end": "calc(env(safe-area-inset-right) * -1)",
 		});
 	});
 
-	describe("Scroll Margin and Padding", () => {
-		test("scroll margin", () => {
-			expectSelectors([".scroll-m-safe"]);
-			expectCSSProperties(
-				Object.fromEntries(
-					directions.map((d) => [
-						`scroll-margin-${d}`,
-						`env(safe-area-inset-${d})`,
-					]),
-				),
-			);
-		});
+	test("padding", () => {
+		expectSelectors([
+			".p-safe",
+			".px-safe",
+			".py-safe",
+			".pt-safe",
+			".pr-safe",
+			".pb-safe",
+			".pl-safe",
+			".ps-safe",
+			".pe-safe",
+		]);
 
-		test("scroll padding", () => {
-			expectSelectors([".scroll-p-safe"]);
-			expectCSSProperties(
-				Object.fromEntries(
-					directions.map((d) => [
-						`scroll-padding-${d}`,
-						`env(safe-area-inset-${d})`,
-					]),
-				),
-			);
+		expectCSSProperties(
+			Object.fromEntries(
+				directions.map((d) => [`padding-${d}`, `env(safe-area-inset-${d})`]),
+			),
+		);
+	});
+
+	test("negative padding", () => {
+		expectSelectors([
+			".-p-safe",
+			".-px-safe",
+			".-py-safe",
+			".-pt-safe",
+			".-pr-safe",
+			".-pb-safe",
+			".-pl-safe",
+			".-ps-safe",
+			".-pe-safe",
+		]);
+
+		expectCSSProperties(
+			Object.fromEntries(
+				directions.map((d) => [
+					`padding-${d}`,
+					`calc(env(safe-area-inset-${d}) * -1)`,
+				]),
+			),
+		);
+	});
+
+	test("logical padding", () => {
+		expectCSSProperties({
+			"padding-inline-start": "env(safe-area-inset-left)",
+			"padding-inline-end": "env(safe-area-inset-right)",
 		});
 	});
 
-	describe("Inset Utilities", () => {
-		test("basic inset", () => {
-			expectSelectors([
-				".inset-safe",
-				".inset-x-safe",
-				".inset-y-safe",
-				".start-safe",
-				".end-safe",
-				".top-safe",
-				".right-safe",
-				".bottom-safe",
-				".left-safe",
-			]);
-
-			expectCSSProperties(
-				Object.fromEntries(
-					directions.map((d) => [`${d}`, `env(safe-area-inset-${d})`]),
-				),
-			);
-		});
-
-		test("logical inset", () => {
-			expectCSSProperties({
-				"inset-inline-start": "env(safe-area-inset-left)",
-				"inset-inline-end": "env(safe-area-inset-right)",
-			});
+	test("negative logical padding", () => {
+		expectCSSProperties({
+			"padding-inline-start": "calc(env(safe-area-inset-left) * -1)",
+			"padding-inline-end": "calc(env(safe-area-inset-right) * -1)",
 		});
 	});
 
-	describe("Height Utilities", () => {
-		test("viewport height safe utilities", () => {
-			expectSelectors([
-				".h-screen-safe",
-				".h-vh-safe",
-				".h-dvh-safe",
-				".h-svh-safe",
-				".h-lvh-safe",
-			]);
+	test("scroll margin", () => {
+		expectSelectors([".scroll-m-safe"]);
+		expectCSSProperties(
+			Object.fromEntries(
+				directions.map((d) => [
+					`scroll-margin-${d}`,
+					`env(safe-area-inset-${d})`,
+				]),
+			),
+		);
+	});
 
-			ok(css.includes("calc("));
-			ok(css.includes("100vh"));
-			ok(css.includes("env(safe-area-inset-top)"));
-			ok(css.includes("env(safe-area-inset-bottom)"));
-			ok(css.includes("-webkit-fill-available"));
-		});
+	test("negative scroll margin", () => {
+		expectSelectors([".-scroll-m-safe"]);
+		expectCSSProperties(
+			Object.fromEntries(
+				directions.map((d) => [
+					`scroll-margin-${d}`,
+					`calc(env(safe-area-inset-${d}) * -1)`,
+				]),
+			),
+		);
+	});
 
-		test("min/max height safe utilities", () => {
-			expectSelectors([".min-h-screen-safe", ".max-h-screen-safe"]);
-			ok(css.includes("min-height"));
-			ok(css.includes("max-height"));
-			ok(css.includes("calc("));
-		});
+	test("scroll padding", () => {
+		expectSelectors([".scroll-p-safe"]);
+		expectCSSProperties(
+			Object.fromEntries(
+				directions.map((d) => [
+					`scroll-padding-${d}`,
+					`env(safe-area-inset-${d})`,
+				]),
+			),
+		);
+	});
 
-		test("fill available height", () => {
-			expectSelectors([".h-fill-safe", ".min-h-fill-safe", ".max-h-fill-safe"]);
-			ok(css.includes(css, "height: -webkit-fill-available"));
+	test("negative scroll padding", () => {
+		expectSelectors([".-scroll-p-safe"]);
+		expectCSSProperties(
+			Object.fromEntries(
+				directions.map((d) => [
+					`scroll-padding-${d}`,
+					`calc(env(safe-area-inset-${d}) * -1)`,
+				]),
+			),
+		);
+	});
+
+	test("inset", () => {
+		expectSelectors([
+			".inset-safe",
+			".inset-x-safe",
+			".inset-y-safe",
+			".start-safe",
+			".end-safe",
+			".top-safe",
+			".right-safe",
+			".bottom-safe",
+			".left-safe",
+		]);
+
+		expectCSSProperties(
+			Object.fromEntries(
+				directions.map((d) => [`${d}`, `env(safe-area-inset-${d})`]),
+			),
+		);
+	});
+
+	test("negative inset", () => {
+		expectSelectors([
+			".-inset-safe",
+			".-inset-x-safe",
+			".-inset-y-safe",
+			".-start-safe",
+			".-end-safe",
+			".-top-safe",
+			".-right-safe",
+			".-bottom-safe",
+			".-left-safe",
+		]);
+
+		expectCSSProperties(
+			Object.fromEntries(
+				directions.map((d) => [`${d}`, `calc(env(safe-area-inset-${d}) * -1)`]),
+			),
+		);
+	});
+
+	test("logical inset", () => {
+		expectCSSProperties({
+			"inset-inline-start": "env(safe-area-inset-left)",
+			"inset-inline-end": "env(safe-area-inset-right)",
 		});
 	});
 
-	describe("Offset Variant Utilities", () => {
-		test("margin, padding, inset, scroll-margin", () => {
-			expectSelectors([
-				".m-safe-offset-4",
-				".mx-safe-offset-2",
-				".my-safe-offset-1",
-				".mt-safe-offset-8",
-				".p-safe-offset-4",
-				".px-safe-offset-2",
-				".py-safe-offset-1",
-				".pt-safe-offset-8",
-				".inset-safe-offset-4",
-				".top-safe-offset-2",
-				".right-safe-offset-1",
-				".scroll-m-safe-offset-4",
-				".scroll-mx-safe-offset-2",
-			]);
-
-			ok(css.includes("env(safe-area-inset-top)"));
-			ok(css.includes("1rem") || css.includes("var(--spacing)"));
+	test("negative logical inset", () => {
+		expectCSSProperties({
+			"inset-inline-start": "calc(env(safe-area-inset-left) * -1)",
+			"inset-inline-end": "calc(env(safe-area-inset-right) * -1)",
 		});
 	});
 
-	describe("Or Variant Utilities", () => {
-		test("margin, padding, inset, scroll-padding", () => {
-			expectSelectors([
-				".m-safe-or-4",
-				".mx-safe-or-2",
-				".my-safe-or-1",
-				".mt-safe-or-8",
-				".p-safe-or-4",
-				".px-safe-or-2",
-				".py-safe-or-1",
-				".pt-safe-or-8",
-				".inset-safe-or-4",
-				".top-safe-or-2",
-				".right-safe-or-1",
-				".scroll-p-safe-or-4",
-				".scroll-px-safe-or-2",
-			]);
+	test("height", () => {
+		expectSelectors([
+			".h-screen-safe",
+			".h-vh-safe",
+			".h-dvh-safe",
+			".h-svh-safe",
+			".h-lvh-safe",
+			".min-h-screen-safe",
+			".max-h-screen-safe",
+			".h-fill-safe",
+			".min-h-fill-safe",
+			".max-h-fill-safe",
+		]);
 
-			ok(css.includes("max("));
-			ok(css.includes("env(safe-area-inset-top)"));
-		});
+		ok(css.includes("calc("));
+		ok(css.includes("100vh"));
+		ok(css.includes("env(safe-area-inset-top)"));
+		ok(css.includes("env(safe-area-inset-bottom)"));
+		ok(css.includes("-webkit-fill-available"));
+		ok(css.includes("min-height"));
+		ok(css.includes("max-height"));
+		ok(css.includes("calc("));
+		ok(css.includes("height: -webkit-fill-available"));
 	});
 
-	describe("Combinations and Edge Cases", () => {
-		test("combination utilities", () => {
-			expectSelectors([
-				".m-safe",
-				".p-safe-offset-4",
-				".h-screen-safe",
-				".inset-safe-or-2",
-			]);
-		});
-
-		test("viewport variations", () => {
-			["100vh", "100dvh", "100svh", "100lvh"].forEach((unit) => {
-				ok(css.includes(unit), `Missing ${unit}`);
-			});
-		});
+	test("offset", () => {
+		expectSelectors([
+			".m-safe-offset-4",
+			".p-safe-offset-4",
+			".inset-safe-offset-4",
+			".scroll-m-safe-offset-4",
+		]);
 	});
 
-	describe("CSS Output Validation", () => {
-		test("env() formatting", () => {
-			directions.forEach((dir) => {
-				ok(css.includes(`env(safe-area-inset-${dir})`));
-			});
-		});
+	test("negative offset", () => {
+		expectSelectors([
+			".-m-safe-offset-4",
+			".-p-safe-offset-4",
+			".-inset-safe-offset-4",
+			".-scroll-m-safe-offset-4",
+		]);
+	});
 
-		test("calc() expressions", () => {
-			ok(css.includes("calc("));
-			ok(css.includes("100vh"));
-			ok(css.includes("env(safe-area-inset-top)"));
-			ok(css.includes("env(safe-area-inset-bottom)"));
-		});
+	test("or", () => {
+		expectSelectors([
+			".m-safe-or-4",
+			".p-safe-or-4",
+			".inset-safe-or-4",
+			".scroll-m-safe-or-4",
+		]);
+
+		ok(css.includes("max("));
+	});
+
+	test("negative or", () => {
+		expectSelectors([
+			".-m-safe-or-4",
+			".-p-safe-or-4",
+			".-inset-safe-or-4",
+			".-scroll-m-safe-or-4",
+		]);
+
+		ok(css.includes("min("));
 	});
 });


### PR DESCRIPTION
This commit adds the negative variant for our existing utilities (where
applicable). Tests have been simplified, i.e. flattened. Conveniently,
the current test output fits on a lil laptop screen.